### PR TITLE
Fix not working in kotlin 1.9.10

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -13,6 +13,12 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ allprojects {
     }
 }
 
-val projectJvmTarget = JavaVersion.VERSION_11.toString()
+val projectJvmTarget = JavaVersion.VERSION_17.toString()
 
 subprojects {
     pluginManager.configureSpotlessIntegration(subProject = project)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,14 +11,14 @@ buildscript {
     }
 
     dependencies {
-        classpath(kotlin("gradle-plugin", version = "1.6.10"))
+        classpath(kotlin("gradle-plugin", version = "1.9.10"))
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.25.3")
     }
 }
 
 plugins {
-    kotlin("jvm") version "1.6.10" apply false
+    kotlin("jvm") version "1.9.10" apply false
     id("com.diffplug.spotless")
 }
 
@@ -39,7 +39,7 @@ subprojects {
 
         kotlinOptions {
             jvmTarget = projectJvmTarget
-            languageVersion = "1.6"
+            languageVersion = "1.9"
         }
     }
 }

--- a/enum-convertible-annotations/gradle.properties
+++ b/enum-convertible-annotations/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=enum-convertible-annotations
-VERSION_NAME=1.0.4-aplha01
+VERSION_NAME=1.0.4-aplha02
 
 POM_NAME=Enum Convertible Annotations
 POM_DESCRIPTION=Annotations that are used from KSP processor to auto-generate mappers for enums.

--- a/enum-convertible-annotations/src/main/kotlin/io/github/bluegroundltd/enumconvertible/EnumConvertibleKey.kt
+++ b/enum-convertible-annotations/src/main/kotlin/io/github/bluegroundltd/enumconvertible/EnumConvertibleKey.kt
@@ -36,5 +36,5 @@ package io.github.bluegroundltd.enumconvertible
  * As we can see, the naming convention for the generated functions is the the `from` prefix with
  * the name of the key. So, for the key `rawValue` the `fromRawValue` will be generated.
  */
-@Target(AnnotationTarget.FIELD)
+@Target(AnnotationTarget.VALUE_PARAMETER)
 annotation class EnumConvertibleKey

--- a/enum-convertible-processor/gradle.properties
+++ b/enum-convertible-processor/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.bluegroundltd
 POM_ARTIFACT_ID=enum-convertible
-VERSION_NAME=1.0.4-aplha01
+VERSION_NAME=1.0.4-aplha02
 
 POM_NAME=Enum Convertible
 POM_DESCRIPTION=KSP processor that auto-generates mappers for enums.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("jvm")
+    id("com.google.devtools.ksp") version "1.9.10-1.0.13"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Kotlin Dependencies
+    implementation(Dependencies.Kotlin.KOTLIN)
+    implementation(Dependencies.Kotlin.KSP)
+
+    implementation(project(":enum-convertible-annotations"))
+    ksp(project(":enum-convertible-processor"))
+
+    testImplementation(TestDependencies.JUnit.JUNIT)
+}

--- a/sample/src/main/kotlin/io/github/bluegroundltd/sample/MyEnum.kt
+++ b/sample/src/main/kotlin/io/github/bluegroundltd/sample/MyEnum.kt
@@ -1,0 +1,13 @@
+package io.github.bluegroundltd.sample
+
+import io.github.bluegroundltd.enumconvertible.DefaultEnumConvertible
+import io.github.bluegroundltd.enumconvertible.EnumConvertible
+import io.github.bluegroundltd.enumconvertible.EnumConvertibleKey
+
+@EnumConvertible
+enum class MyEnum(@EnumConvertibleKey val value: String) {
+    FIRST_ENTRY("first"),
+
+    @DefaultEnumConvertible
+    SECOND_ENTRY("second")
+}

--- a/sample/src/main/kotlin/io/github/bluegroundltd/sample/MyEnumNoDefault.kt
+++ b/sample/src/main/kotlin/io/github/bluegroundltd/sample/MyEnumNoDefault.kt
@@ -1,0 +1,11 @@
+package io.github.bluegroundltd.sample
+
+import io.github.bluegroundltd.enumconvertible.EnumConvertible
+import io.github.bluegroundltd.enumconvertible.EnumConvertibleKey
+
+@EnumConvertible
+enum class MyEnumNoDefault(@EnumConvertibleKey val value: String) {
+    FIRST_ENTRY("first"),
+
+    SECOND_ENTRY("second")
+}

--- a/sample/src/test/kotlin/io/github/bluegroundltd/sample/MyEnumNoDefaultTest.kt
+++ b/sample/src/test/kotlin/io/github/bluegroundltd/sample/MyEnumNoDefaultTest.kt
@@ -1,0 +1,19 @@
+package io.github.bluegroundltd.sample
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MyEnumNoDefaultTest {
+
+    @Test
+    fun `should map unknown string value to null if no value is marked with @DefaultEnumConvertible`() {
+        // Given
+        val unknownValue = "unknown string value"
+
+        // When
+        val mappedValue = MyEnumNoDefaultMapper.fromValue(value = unknownValue)
+
+        // Then
+        assertEquals(null, mappedValue)
+    }
+}

--- a/sample/src/test/kotlin/io/github/bluegroundltd/sample/MyEnumTest.kt
+++ b/sample/src/test/kotlin/io/github/bluegroundltd/sample/MyEnumTest.kt
@@ -1,0 +1,31 @@
+package io.github.bluegroundltd.sample
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MyEnumTest {
+
+    @Test
+    fun `should map string value to enum value`() {
+        // Given
+        val firstEntryValue = MyEnum.FIRST_ENTRY.value
+
+        // When
+        val firstEntryEnumValue = MyEnumMapper.fromValue(value = firstEntryValue)
+
+        // Then
+        assertEquals(MyEnum.FIRST_ENTRY, firstEntryEnumValue)
+    }
+
+    @Test
+    fun `should map unknown string value to the enum value marked with @DefaultEnumConvertible`() {
+        // Given
+        val unknownValue = "unknown string value"
+
+        // When
+        val defaultValue = MyEnumMapper.fromValue(value = unknownValue)
+
+        // Then
+        assertEquals(MyEnum.SECOND_ENTRY, defaultValue)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,4 +13,4 @@ pluginManagement {
 }
 
 rootProject.name = "enum-convertible"
-include(":enum-convertible-annotations", ":enum-convertible-processor")
+include(":enum-convertible-annotations", ":enum-convertible-processor", ":sample")


### PR DESCRIPTION
- Fix not building the `from*` functions in the generated mapper classes.
- Add sample module.